### PR TITLE
fix example code in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ const config = {
 }
 
 const hafas = createHafas(dbProfile, 'my-hafas-rest-api')
-const api = createApi(hafas, config)
+const api = await createApi(hafas, config)
 
 api.listen(3000, (err) => {
 	if (err) console.error(err)


### PR DESCRIPTION
The method `createApi` returns a promise that needs to be awaited, otherwise `api` will be a a pending promise instead of the api client.